### PR TITLE
Issue 2 quit prematurely

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple library for writing command-line applications, inspired by Python's [cm
 
 ----------------------------------------------
 
-***Latest version: v.1.2 (2020-30-10)***
+***Latest version: v.1.3 (2020-27-11)***
 
 ----------------------------------------------
 

--- a/libcmdf.h
+++ b/libcmdf.h
@@ -752,12 +752,20 @@ void cmdf__default_commandloop(void) {
         #ifndef CMDF_READLINE_SUPPORT
             fprintf(CMDF_STDOUT, "%s", cmdf__settings_stack.top->prompt);
             fgets(inputbuff, sizeof(char) * CMDF_MAX_INPUT_BUFFER_LENGTH, CMDF_STDIN);
+
+            /* Check for EOF */
+            if (feof(CMDF_STDIN)) {
+                cmdf__settings_stack.top->exit_flag = 1;
+                continue;
+            }
         #else
             inputbuff = readline(cmdf__settings_stack.top->prompt);
 
-            /* If the buffer wasn't allocated = out of memory, so exit with failure*/
-            if (!inputbuff)
-                exit(CMDF_ERROR_OUT_OF_MEMORY);
+            /* EOF, or failure to allocate a buffer. Means we probably need to exit. */
+            if (!inputbuff) {
+                cmdf__settings_stack.top->exit_flag = 1;
+                continue;
+            }
         #endif
 
         /* Trim string */

--- a/tests/c_test/Makefile
+++ b/tests/c_test/Makefile
@@ -1,13 +1,10 @@
-CFLAGS=-ansi -pedantic -Wall -Werror -ggdb -O0 -D_POSIX_SOURCE
+CFLAGS=-ansi -pedantic -Wall -Werror -ggdb -O0 -D_POSIX_SOURCE -I"../.."
 LDLIBS=-lreadline
 
 ALL: compile_c_test
 
-link_to_lib:
-	ln -s ../../libcmdf.h ./libcmdf.h
-
 c_test: c_test.c
 c_submenu: c_submenu.c
 
-compile_c_test: link_to_lib c_test
-compile_c_submenu: link_to_lib c_submenu
+compile_c_test: c_test
+compile_c_submenu: c_submenu

--- a/tests/cpp_test/Makefile
+++ b/tests/cpp_test/Makefile
@@ -1,11 +1,8 @@
-CXXFLAGS=-Wall -Werror -ggdb -O0
+CXXFLAGS=-Wall -Werror -ggdb -O0 -I"../.."
 LDLIBS=-lreadline
 
 ALL: compile_cpp_test
 
-link_to_lib:
-	ln -s ../../libcmdf.h ./libcmdf.h
-
 cpp_test: cpp_test.cpp
 
-compile_cpp_test: link_to_lib cpp_test
+compile_cpp_test: cpp_test


### PR DESCRIPTION
Fixed #2 where libcmdf quits when an EOF is provided in Readline-enabled mode.
Also made sure that EOFs are handled correctly in regular mode.